### PR TITLE
added ability to view each comic on the main page using arrows

### DIFF
--- a/src/components/AdminPortal.js
+++ b/src/components/AdminPortal.js
@@ -13,9 +13,6 @@ import Typography from "@material-ui/core/Typography";
 import NativeSelect from "@material-ui/core/NativeSelect";
 import FormControl from "@material-ui/core/FormControl";
 
-import Snackbar from "@material-ui/core/Snackbar";
-import MuiAlert from "@material-ui/lab/Alert";
-
 import CustomSnackBar from "../components/CustomSnackBar";
 
 const CDN = process.env.REACT_APP_CDN;
@@ -61,10 +58,6 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-function Alert(props) {
-    return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
-
 const AdminPortal = () => {
     const classes = useStyles();
     const [isLoading, setIsLoading] = useState(true);
@@ -90,19 +83,14 @@ const AdminPortal = () => {
     };
 
     const handleDelete = async (id) => {
-        console.log(`deleting comic with id: ${id}`);
         try {
             await deleteComic(id);
             if (id === 0) {
-                console.log("removing first comic");
                 comics.shift();
             } else if (id === comics.length) {
-                console.log("id is length");
                 comics.pop();
-                console.log(comics);
             } else {
-                let removed = comics.splice(id - 1, 1);
-                console.log(removed);
+                comics.splice(id - 1, 1);
             }
             setComics(() => [...comics]);
             setComicInfo((comicInfo) => ({
@@ -214,7 +202,7 @@ const AdminPortal = () => {
                     </div>
                 </div>
             )}
-            <Snackbar open={success} autoHideDuration={6000} onClose={handleClose}>
+            {/* <Snackbar open={success} autoHideDuration={6000} onClose={handleClose}>
                 <Alert onClose={handleClose} severity="success">
                     <span role="img" aria-label="Popping confetti">
                         🎉
@@ -224,15 +212,35 @@ const AdminPortal = () => {
                         🎉
                     </span>
                 </Alert>
-            </Snackbar>
-            <Snackbar open={error} autoHideDuration={6000} onClose={handleClose}>
+            </Snackbar> */}
+            {/* <Snackbar open={error} autoHideDuration={6000} onClose={handleClose}>
                 <Alert onClose={handleClose} severity="error">
                     Uh oh, something went wrong. Try again?
                     <span role="img" aria-label="Smiling Face with sweat">
                         😅
                     </span>
                 </Alert>
-            </Snackbar>
+            </Snackbar> */}
+            <CustomSnackBar
+                open={success}
+                autoHideDuration={6000}
+                onClose={handleClose}
+                severity="success"
+                emoji="🎉"
+                emojiLabel="Popping confetti"
+                message="Comic updated successfully!"
+                encloseMessage={true}
+            ></CustomSnackBar>
+            <CustomSnackBar
+                open={error}
+                autoHideDuration={6000}
+                onClose={handleClose}
+                severity="error"
+                emoji="😅"
+                emojiLabel="Smiling Face with sweat"
+                message="Uh oh, something went wrong. Try again?"
+                encloseMessage={false}
+            ></CustomSnackBar>
             <CustomSnackBar
                 open={deletedComic}
                 autoHideDuration={6000}
@@ -241,6 +249,7 @@ const AdminPortal = () => {
                 emoji="🎉"
                 emojiLabel="Popping confetti"
                 message="Deleted comic successfully"
+                encloseMessage={true}
             ></CustomSnackBar>
         </div>
     );

--- a/src/components/Comic.js
+++ b/src/components/Comic.js
@@ -1,11 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import GlobalEmojiBar from "../components/GlobalEmojiBar";
-// import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
-// import ArrowBackIosIcon from "@material-ui/icons/ArrowBackIos";
-// import SkipNextIcon from "@material-ui/icons/SkipNext";
-// import SkipPreviousIcon from "@material-ui/icons/SkipPrevious";
-// import Button from "@material-ui/core/Button";
 import FavoriteButton from "../components/FavoriteButton";
 
 const useStyles = makeStyles((theme) => ({
@@ -22,24 +17,24 @@ const useStyles = makeStyles((theme) => ({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        height: "90vh",
-        margin: "0 2vw",
+        // height: "100vh", //90
+        margin: "0 1vw",
         flexDirection: "column",
-        [theme.breakpoints.up("sm")]: {
-            // minHeight: "885px",
-            minHeight: "935px",
-        },
-        [theme.breakpoints.down("md")]: {
-            height: "80vh",
-        },
-        [theme.breakpoints.up("lg")]: {
-            height: "100vh",
-        },
+        // [theme.breakpoints.up("sm")]: {
+        //     minHeight: "935px",
+        // },
+        // [theme.breakpoints.down("md")]: {
+        //     height: "80vh",
+        // },
+        // [theme.breakpoints.up("lg")]: {
+        //     height: "100vh",
+        // },
     },
     emojibar: {
         display: "flex",
         flexDirection: "row",
         justifyContent: "center",
+        // margin: "0.5vh 0 0.5vh 0",
         [theme.breakpoints.up("sm")]: {
             width: "100%",
             flexDirection: "column",
@@ -55,23 +50,23 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const Comic = ({ src, srcSet, handlePreviousComic, handleNextComic, id, chipData, setChipData, name }) => {
+const Comic = ({ src, srcSet, id, chipData, setChipData, name, handleNextComic, handlePreviousComic, count }) => {
     const classes = useStyles();
 
     return (
         <div className={classes.flex}>
-            {/* <SkipPreviousIcon></SkipPreviousIcon>
-            <Button onClick={handlePreviousComic}>
-                <ArrowBackIosIcon></ArrowBackIosIcon>
-            </Button> */}
             <img className={classes.comic} srcSet={srcSet} src={src} alt="Grubby Comic" />
-            {/* <Button onClick={handleNextComic}>
-                <ArrowForwardIosIcon></ArrowForwardIosIcon>
-            </Button>
-            <SkipNextIcon></SkipNextIcon> */}
+
             <div className={classes.emojibar}>
                 <FavoriteButton orientation="left"></FavoriteButton>
-                <GlobalEmojiBar id={id} chipData={chipData} setChipData={setChipData}></GlobalEmojiBar>
+                <GlobalEmojiBar
+                    id={id}
+                    chipData={chipData}
+                    setChipData={setChipData}
+                    handleNextComic={handleNextComic}
+                    handlePreviousComic={handlePreviousComic}
+                    count={count}
+                ></GlobalEmojiBar>
                 <FavoriteButton orientation="right" comicID={id} name={name}></FavoriteButton>
             </div>
         </div>

--- a/src/components/CustomSnackBar.js
+++ b/src/components/CustomSnackBar.js
@@ -6,15 +6,26 @@ function Alert(props) {
     return <MuiAlert elevation={6} variant="filled" {...props} />;
 }
 
-const CustomSnackBar = ({ open, onClose, severity, autoHideDuration, emoji, emojiLabel, message }) => {
+const CustomSnackBar = ({
+    open,
+    onClose,
+    severity,
+    autoHideDuration,
+    emoji,
+    emojiLabel,
+    message,
+    encloseMessage = false,
+}) => {
     return (
         <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={onClose}>
             <Alert onClose={onClose} severity={severity}>
-                <span role="img" aria-label={emojiLabel}>
-                    {emoji}
-                </span>
+                {encloseMessage && (
+                    <span role="img" aria-label={emojiLabel}>
+                        {emoji}
+                    </span>
+                )}
                 {message}
-                <span role="img" aria-label={emojiLabel}>
+                <span role="img" aria-label={emojiLabel} style={{ marginLeft: "5px" }}>
                     {emoji}
                 </span>
             </Alert>

--- a/src/components/DisplayComic.js
+++ b/src/components/DisplayComic.js
@@ -1,16 +1,42 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import Comic from "./Comic";
-import axios from "axios";
-// import { getGlobalEmote } from "../helpers/GrubbyAPI";
+import { getLatestComic, getPreviousComic } from "../helpers/GrubbyAPI";
 
-const BASE_URL = process.env.REACT_APP_SERVER_URL || "http://localhost:5000";
+import { makeStyles } from "@material-ui/core/styles";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
+
 const CDN = process.env.REACT_APP_CDN;
 
+const useStyles = makeStyles((theme) => ({
+    comicWrapper: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    arrow: {
+        cursor: "pointer",
+    },
+    invisible: {
+        visibility: "hidden",
+    },
+    hide: {
+        display: "none",
+    },
+}));
+
 const DisplayComic = () => {
-    const [src, setSrc] = useState("https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/960/blur.jpg");
-    const [allImages, setAllImages] = useState([]);
-    const [comicID, setComicID] = useState(null);
-    const [name, setName] = useState(null);
+    const classes = useStyles();
+    const matches = useMediaQuery("(max-width:900px)");
+
+    const [src, setSrc] = useState(`${CDN}/800/blur.jpg`);
+    const [srcSet, setSrcSet] = useState("");
+    const [comicID, setComicID] = useState(0);
+    const [name, setName] = useState("");
+    const [count, setCount] = useState(null);
     const [chipData, setChipData] = useState([
         { key: 0, label: "Laughing", icon: "😂", count: 0 },
         { key: 1, label: "Clapping", icon: "👏", count: 0 },
@@ -19,33 +45,70 @@ const DisplayComic = () => {
         { key: 4, label: "Clown", icon: "🤡", count: 0 },
     ]);
 
-    let srcSet = allImages.join();
+    const [prevComic, setPrevComic] = useState({});
+    const [emoteData, setEmoteData] = useState({});
+    const [visitedComics, setVisitedComics] = useState({});
 
-    const handlePreviousComic = () => {
-        console.log("loading previous comic");
+    const rightArrow = comicID === count ? classes.invisible : classes.arrow;
+
+    const makeSrcSet = (name) => {
+        const sizes = ["320", "384", "512", "683", "800"];
+        let urls = [];
+        sizes.forEach((size) => urls.push(`${CDN}/${size}/${name} ${size}w`));
+        let srcSet = urls.join();
+        return srcSet;
     };
 
-    const handleNextComic = () => {
-        console.log("loading next comic");
+    const handlePreviousComic = async (id) => {
+        try {
+            if (id === 0) {
+                return;
+            }
+            visitedComics[comicID] = { comic_id: comicID, name: name, emotes: { ...emoteData } };
+            setVisitedComics(() => ({
+                ...visitedComics,
+            }));
+            comicSwitch(prevComic);
+        } catch (error) {
+            return;
+        }
     };
+
+    const handleNextComic = async (id) => {
+        try {
+            if (id > count) {
+                return;
+            }
+
+            comicSwitch(visitedComics[id]);
+        } catch (error) {
+            return;
+        }
+    };
+
+    const comicSwitch = useCallback((data) => {
+        let { name, comic_id, emotes } = data;
+        setComicID(comic_id);
+        setName(name);
+        let srcSet = makeSrcSet(name);
+        setSrcSet(() => srcSet);
+        setEmoteData(() => ({ ...emotes }));
+        setChipData((chipData) =>
+            chipData.map((data) => ({
+                ...data,
+                count: +emotes[data.label],
+            }))
+        );
+    }, []);
 
     useEffect(() => {
         async function getComic() {
             try {
-                const sizes = ["320", "384", "512", "683", "800", "960"];
-                let result = await axios.get(`${BASE_URL}/comic/latest`);
-                setSrc(`${CDN}/960/${result.data.comic.name}`);
-                setComicID(result.data.comic.comic_id);
-                setName(result.data.comic.name);
-                let urls = [];
-                sizes.forEach((size) => urls.push(`${CDN}/${size}/${result.data.comic.name} ${size}w`));
-                setAllImages(urls);
-                setChipData((chipData) =>
-                    chipData.map((data) => ({
-                        ...data,
-                        count: +result.data.comic.emotes[data.label],
-                    }))
-                );
+                let result = await getLatestComic();
+                comicSwitch(result);
+                let { comic_id, emotes } = result;
+                setCount(() => comic_id);
+                setEmoteData(() => ({ ...emotes }));
             } catch (error) {
                 setSrc(`${CDN}/960/Grubby_1.jpg`);
                 return;
@@ -53,19 +116,50 @@ const DisplayComic = () => {
         }
 
         getComic();
-    }, []);
+    }, [comicSwitch]);
+
+    useEffect(() => {
+        async function preload(id) {
+            try {
+                if (id === 0) {
+                    return;
+                }
+                let prevID = id - 1;
+                let preloadComic = await getPreviousComic(prevID);
+                let { name } = preloadComic;
+                let srcSet = makeSrcSet(name);
+                new Image().setAttribute("srcset", srcSet);
+                setPrevComic(() => ({ ...preloadComic }));
+            } catch (error) {
+                return;
+            }
+        }
+
+        preload(comicID);
+    }, [comicID]);
 
     return (
-        <Comic
-            src={src}
-            srcSet={srcSet}
-            handlePreviousComic={handlePreviousComic}
-            handleNextComic={handleNextComic}
-            id={comicID}
-            chipData={chipData}
-            setChipData={setChipData}
-            name={name}
-        ></Comic>
+        <div className={classes.comicWrapper}>
+            <ArrowBackIcon
+                className={matches ? classes.hide : classes.arrow}
+                onClick={() => handlePreviousComic(comicID - 1)}
+            />
+            <Comic
+                src={src}
+                srcSet={srcSet}
+                id={comicID}
+                chipData={chipData}
+                setChipData={setChipData}
+                name={name}
+                handleNextComic={handleNextComic}
+                handlePreviousComic={handlePreviousComic}
+                count={count}
+            ></Comic>
+            <ArrowForwardIcon
+                className={matches ? classes.hide : rightArrow}
+                onClick={() => handleNextComic(comicID + 1)}
+            />
+        </div>
     );
 };
 

--- a/src/components/FavoriteButton.js
+++ b/src/components/FavoriteButton.js
@@ -68,7 +68,7 @@ const useStyles = makeStyles((theme) => ({
         },
         [theme.breakpoints.down("md")]: {
             // marginLeft: 0,
-            margin: "8px auto 8px auto",
+            margin: "8px auto 10px auto",
             // width: "20%",
             maxWidth: "72px",
         },
@@ -127,6 +127,8 @@ const FavoriteButton = ({ orientation, comicID, favorite = false, name }) => {
                     if (favorites[i].comic_id === comicID) {
                         setIsFavorite(() => true);
                         break;
+                    } else {
+                        setIsFavorite(() => false);
                     }
                 }
             } else {

--- a/src/components/GlobalEmojiBar.js
+++ b/src/components/GlobalEmojiBar.js
@@ -5,14 +5,14 @@ import { getUserEmoteData } from "../helpers/GrubbyAPI";
 import { makeStyles, createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import Chip from "@material-ui/core/Chip";
 import Paper from "@material-ui/core/Paper";
-import Snackbar from "@material-ui/core/Snackbar";
-import MuiAlert from "@material-ui/lab/Alert";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
+
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 
 import { sendUserEmoteData, updateUserEmoteData, deleteReaction } from "../helpers/GrubbyAPI";
 
-function Alert(props) {
-    return <MuiAlert elevation={6} variant="filled" {...props} />;
-}
+import CustomSnackBar from "../components/CustomSnackBar";
 
 const theme = createMuiTheme({
     palette: {
@@ -41,13 +41,39 @@ const useStyles = makeStyles((theme) => ({
     chip: {
         margin: theme.spacing(0.5),
     },
+    leftArrow: {
+        cursor: "pointer",
+        float: "left",
+        fontSize: "2.5em",
+    },
+    rightArrow: {
+        cursor: "pointer",
+        float: "right",
+        fontSize: "2.5em",
+    },
+    invisible: {
+        visibility: "hidden",
+    },
+    hide: {
+        display: "none",
+    },
+    arrowWrapper: {
+        width: "100%",
+        // margin: "2vh 0",
+        margin: "0.5vh 0",
+        padding: theme.spacing(0.5),
+    },
 }));
 
-function GlobalEmojiBar({ id, chipData, setChipData }) {
+function GlobalEmojiBar({ id, chipData, setChipData, count, handleNextComic, handlePreviousComic }) {
     const classes = useStyles();
+    const matches = useMediaQuery("(max-width:900px)");
+
     const { user } = useContext(UserContext);
     const [reaction, setReaction] = useState("");
     const [error, setError] = useState(false);
+
+    const rightArrow = id === count ? classes.invisible : classes.rightArrow;
 
     const handleClick = async (newReaction) => {
         if (!user) {
@@ -123,6 +149,16 @@ function GlobalEmojiBar({ id, chipData, setChipData }) {
 
     return (
         <ThemeProvider theme={theme}>
+            <div className={matches ? classes.arrowWrapper : classes.hide}>
+                <ArrowBackIcon
+                    className={matches ? classes.leftArrow : classes.hide}
+                    onClick={() => handlePreviousComic(id - 1)}
+                />
+                <ArrowForwardIcon
+                    className={matches ? rightArrow : classes.hide}
+                    onClick={() => handleNextComic(id + 1)}
+                />
+            </div>
             {chipData && (
                 <div>
                     <Paper component="ul" className={classes.root}>
@@ -149,14 +185,17 @@ function GlobalEmojiBar({ id, chipData, setChipData }) {
                             );
                         })}
                     </Paper>
-                    <Snackbar open={error} autoHideDuration={6000} onClose={handleClose}>
-                        <Alert onClose={handleClose} severity="info">
-                            You must be logged in to submit a reaction!
-                            <span role="img" aria-label="Winking Face" style={{ marginLeft: "5px" }}>
-                                😉
-                            </span>
-                        </Alert>
-                    </Snackbar>
+
+                    <CustomSnackBar
+                        open={error}
+                        autoHideDuration={6000}
+                        onClose={handleClose}
+                        severity="info"
+                        emoji="😉"
+                        emojiLabel="Winking Face"
+                        message={"You must be logged in to submit a reaction!"}
+                        encloseMessage={false}
+                    />
                 </div>
             )}
             {!chipData && null}

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -24,9 +24,9 @@ function Alert(props) {
 }
 
 const images = [
-    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/960/Grubby_71.jpg",
-    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/960/Grubby_177.jpg",
-    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/960/Grubby_146.jpg",
+    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/800/Grubby_71.jpg",
+    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/800/Grubby_177.jpg",
+    "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/800/Grubby_146.jpg",
 ];
 
 const useStyles = makeStyles((theme) => ({
@@ -42,7 +42,8 @@ const useStyles = makeStyles((theme) => ({
         backgroundAttachment: "fixed",
         backgroundPosition: "center",
         minHeight: "calc(99vh - 64px)",
-        height: "120%",
+        padding: "4vh 0 8vh 0",
+        // height: "120%",
         // padding: "1.5vh",
     },
 
@@ -123,7 +124,8 @@ const useStyles = makeStyles((theme) => ({
     comicfont: {
         fontFamily: "comicfont",
         color: "black",
-        marginTop: "1vh",
+        // marginTop: "1vh",
+        margin: "2vh 0 5vh 0",
         [theme.breakpoints.down("sm")]: {
             fontSize: "50px",
         },
@@ -131,7 +133,8 @@ const useStyles = makeStyles((theme) => ({
     comicFontSmall: {
         fontFamily: "comicfont",
         color: "black",
-        marginTop: "1vh",
+        // marginTop: "1vh",
+        margin: "2vh 0 5vh 0",
         fontSize: "40px",
     },
     speechIcon: {

--- a/src/components/ScrollArrow.js
+++ b/src/components/ScrollArrow.js
@@ -10,7 +10,7 @@ const ScrollArrow = () => {
     const [showScroll, setShowScroll] = useState(null);
     // Check the scroll state, re-memoize when scroll state changes.
     const checkScrollTop = useCallback(() => {
-        const headerHeight = 400;
+        const headerHeight = 700;
 
         if (!showScroll && window.pageYOffset > headerHeight) {
             setShowScroll(true);

--- a/src/helpers/GrubbyAPI.js
+++ b/src/helpers/GrubbyAPI.js
@@ -68,6 +68,15 @@ export async function checkTokenStatus(token) {
     }
 }
 
+export async function getLatestComic() {
+    try {
+        let result = await axios.get(`${BASE_URL}/comic/latest`);
+        return result.data.comic;
+    } catch (error) {
+        console.error("API Error:", error.response);
+    }
+}
+
 export async function getAllComics(page) {
     try {
         let result = await axios.get(`${BASE_URL}/comic/all?page=${page}`, { withCredentials: true });
@@ -81,6 +90,15 @@ export async function getAllAdminComics() {
     try {
         let result = await axios.get(`${BASE_URL}/admin/comics`, { withCredentials: true });
         return result.data;
+    } catch (error) {
+        console.error("API Error:", error.response);
+    }
+}
+
+export async function getPreviousComic(id) {
+    try {
+        let result = await axios.get(`${BASE_URL}/comic/${id}`);
+        return result.data.comic;
     } catch (error) {
         console.error("API Error:", error.response);
     }


### PR DESCRIPTION
Added support for viewing each comic on the main page, through the use of arrows. The data for the next comic in line is loaded behind the scenes before the user requests it (same for the image itself). This will hopefully translate to a faster user experience while not loading too many of the comics that the user may never need.

Additional fixes: 
- revamped UI spacing
- replaced SnackBar component with CustomSnackBar
- minor ScrollArrow tweak (when it appears on the screen)