### PR TITLE
added support for first, last, and random arrows

### DIFF
--- a/src/components/Comic.js
+++ b/src/components/Comic.js
@@ -2,6 +2,7 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import GlobalEmojiBar from "../components/GlobalEmojiBar";
 import FavoriteButton from "../components/FavoriteButton";
+import RandomComicButton from "../components/RandomComicButton";
 
 const useStyles = makeStyles((theme) => ({
     comic: {
@@ -33,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
             width: "100%",
             flexDirection: "column",
         },
-        [theme.breakpoints.up("lg")]: {
+        [theme.breakpoints.up("md")]: {
             width: "90%",
             flexDirection: "row",
         },
@@ -49,6 +50,28 @@ const useStyles = makeStyles((theme) => ({
         margin: "0vh 1vw",
         userSelect: "none",
     },
+    right: {
+        margin: "8px",
+        backgroundColor: "#FFFFFF",
+        width: "58px",
+
+        [theme.breakpoints.up("sm")]: {
+            marginRight: 0,
+        },
+        [theme.breakpoints.up("md")]: {
+            marginRight: 0,
+        },
+        [theme.breakpoints.down("md")]: {
+            margin: "8px auto 10px auto",
+            maxWidth: "72px",
+        },
+        [theme.breakpoints.up("lg")]: {
+            marginRight: "auto",
+        },
+        "&:hover": {
+            background: "rgb(234, 234, 234)",
+        },
+    },
 }));
 
 const Comic = ({
@@ -60,9 +83,13 @@ const Comic = ({
     name,
     handleNextComic,
     handlePreviousComic,
+    handleRandomComic,
     count,
     visible,
     isLoading,
+    reaction,
+    setReaction,
+    hideRandom,
 }) => {
     const classes = useStyles();
 
@@ -76,15 +103,19 @@ const Comic = ({
             />
 
             <div className={classes.emojibar}>
-                <FavoriteButton orientation="left"></FavoriteButton>
+                <RandomComicButton visible={hideRandom} handleRandomComic={handleRandomComic} />
+                {/* <FavoriteButton orientation="left"></FavoriteButton> */}
                 <GlobalEmojiBar
                     id={id}
                     chipData={chipData}
                     setChipData={setChipData}
                     handleNextComic={handleNextComic}
                     handlePreviousComic={handlePreviousComic}
+                    handleRandomComic={handleRandomComic}
                     count={count}
                     isLoading={isLoading}
+                    reaction={reaction}
+                    setReaction={setReaction}
                 ></GlobalEmojiBar>
                 <FavoriteButton orientation="right" comicID={id} name={name}></FavoriteButton>
             </div>

--- a/src/components/DisplayComic.js
+++ b/src/components/DisplayComic.js
@@ -1,17 +1,21 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useContext } from "react";
 import Comic from "./Comic";
-import { getLatestComic, getPreviousComic } from "../helpers/GrubbyAPI";
+import { getLatestComic, getComic, getUserEmoteData, getGlobalEmote } from "../helpers/GrubbyAPI";
 
-import { makeStyles } from "@material-ui/core/styles";
+import { makeStyles, createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import Typography from "@material-ui/core/Typography";
 
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import IconButton from "@material-ui/core/IconButton";
+import SkipNextIcon from "@material-ui/icons/SkipNext";
+import SkipPreviousIcon from "@material-ui/icons/SkipPrevious";
 
 import Lottie from "lottie-react";
 import noAccessData from "../lotties/no-access.json";
+
+import { UserContext } from "./UserContext";
 
 const CDN = process.env.REACT_APP_CDN;
 
@@ -22,6 +26,14 @@ const makeSrcSet = (name) => {
     let srcSet = urls.join();
     return srcSet;
 };
+
+const theme = createMuiTheme({
+    palette: {
+        primary: {
+            main: "#FFFFFF",
+        },
+    },
+});
 
 const useStyles = makeStyles((theme) => ({
     comicWrapper: {
@@ -66,7 +78,8 @@ const useStyles = makeStyles((theme) => ({
 
 const DisplayComic = () => {
     const classes = useStyles();
-    const matches = useMediaQuery("(max-width:900px)");
+    const matches = useMediaQuery("(max-width:900px)"); //900
+    const { user } = useContext(UserContext);
 
     const [src, setSrc] = useState(`${CDN}/800/blur.jpg`);
     const [srcSet, setSrcSet] = useState("");
@@ -75,19 +88,59 @@ const DisplayComic = () => {
     const [count, setCount] = useState(null);
 
     const [chipData, setChipData] = useState([
-        { key: 0, label: "Laughing", icon: "😂", count: 0 },
-        { key: 1, label: "Clapping", icon: "👏", count: 0 },
-        { key: 2, label: "ROFL", icon: "🤣", count: 0 },
-        { key: 3, label: "Grinning", icon: "😄", count: 0 },
-        { key: 4, label: "Clown", icon: "🤡", count: 0 },
+        {
+            key: 0,
+            label: "Laughing",
+            icon: "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/Emoji1_24x24.png",
+            count: 0,
+        },
+        {
+            key: 1,
+            label: "Clapping",
+            icon: "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/Emoji2_24x24.png",
+            count: 0,
+        },
+        {
+            key: 2,
+            label: "ROFL",
+            icon: "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/Emoji3_24x24.png",
+            count: 0,
+        },
+        {
+            key: 3,
+            label: "Grinning",
+            icon: "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/Emoji4_24x24.png",
+            count: 0,
+        },
+        {
+            key: 4,
+            label: "Clown",
+            icon: "https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/Emoji5_24x24.png",
+            count: 0,
+        },
     ]);
+    // const [chipData, setChipData] = useState([
+    //     { key: 0, label: "Laughing", icon: "😂", count: 0 },
+    //     { key: 1, label: "Clapping", icon: "👏", count: 0 },
+    //     { key: 2, label: "ROFL", icon: "🤣", count: 0 },
+    //     { key: 3, label: "Grinning", icon: "😄", count: 0 },
+    //     { key: 4, label: "Clown", icon: "🤡", count: 0 },
+    // ]);
 
     const [prevComic, setPrevComic] = useState({});
+    const [nextComic, setNextComic] = useState({});
     const [emoteData, setEmoteData] = useState({});
     const [visitedComics, setVisitedComics] = useState({});
 
     const [isLoading, setIsLoading] = useState(true);
     const [unavailable, setUnavailable] = useState(false);
+
+    const [firstComic, setFirstComic] = useState({});
+    const [lastComic, setLastComic] = useState({});
+    const [randomComic, setRandomComic] = useState({});
+    const [usedRandom, setUsedRandom] = useState(true);
+
+    const [reaction, setReaction] = useState("");
 
     const rightArrow = isLoading || comicID === count ? classes.invisible : classes.arrow;
     const leftArrow = comicID === 1 ? classes.invisible : classes.arrow;
@@ -113,11 +166,45 @@ const DisplayComic = () => {
             if (id > count) {
                 return;
             }
+            if (visitedComics[id]) {
+                let result = await getGlobalEmote(chipData, id);
+                visitedComics[id] = { ...visitedComics[id], emotes: { ...result } };
+                setVisitedComics(() => ({
+                    ...visitedComics,
+                }));
+                setEmoteData(() => ({ ...result }));
+                // setChipData((chipData) =>
+                //     chipData.map((data) => ({
+                //         ...data,
+                //         count: +result[data.label],
+                //     }))
+                // );
+                comicSwitch(visitedComics[id]);
+            } else {
+                visitedComics[comicID] = { comic_id: comicID, name: name, emotes: { ...emoteData } };
+                setVisitedComics(() => ({
+                    ...visitedComics,
+                }));
+                comicSwitch(nextComic);
+            }
 
-            comicSwitch(visitedComics[id]);
+            // comicSwitch(visitedComics[id], emoteData);
         } catch (error) {
             return;
         }
+    };
+
+    const handleFirstComic = () => {
+        comicSwitch(firstComic);
+    };
+
+    const handleLastComic = () => {
+        comicSwitch(lastComic);
+    };
+
+    const handleRandomComic = () => {
+        comicSwitch(randomComic);
+        setUsedRandom(() => true);
     };
 
     const comicSwitch = useCallback((data) => {
@@ -127,6 +214,7 @@ const DisplayComic = () => {
         setSrc(() => `${CDN}/800/${name}`);
         let newSrcSet = makeSrcSet(name);
         setSrcSet(() => newSrcSet);
+
         setEmoteData(() => ({ ...emotes }));
         setChipData((chipData) =>
             chipData.map((data) => ({
@@ -146,6 +234,7 @@ const DisplayComic = () => {
                 let { comic_id } = result;
                 setCount(() => comic_id);
                 setIsLoading(() => false);
+                setLastComic(() => ({ ...result }));
             } catch (error) {
                 setUnavailable(() => true);
                 setIsLoading(() => false);
@@ -166,7 +255,7 @@ const DisplayComic = () => {
                 if (prevID < 1) {
                     return;
                 }
-                let preloadComic = await getPreviousComic(prevID);
+                let preloadComic = await getComic(prevID);
                 let { name } = preloadComic;
                 let srcSet = makeSrcSet(name);
                 new Image().setAttribute("srcset", srcSet);
@@ -178,6 +267,77 @@ const DisplayComic = () => {
 
         preload(comicID);
     }, [comicID]);
+
+    useEffect(() => {
+        async function getFirstComic(id) {
+            let firstComicInfo = await getComic(id);
+            let { name } = firstComicInfo;
+            let srcSet = makeSrcSet(name);
+            new Image().setAttribute("srcset", srcSet);
+            setFirstComic(() => ({ ...firstComicInfo }));
+        }
+
+        getFirstComic(1);
+    }, []);
+
+    useEffect(() => {
+        async function getEmoteData(id) {
+            try {
+                if (user) {
+                    if (id === null || id === undefined || id === 0) {
+                        return;
+                    }
+
+                    let result = await getUserEmoteData(id, user);
+                    setReaction(() => result);
+                } else {
+                    return;
+                }
+            } catch (error) {
+                return;
+            }
+        }
+        getEmoteData(comicID);
+    }, [user, comicID]);
+
+    useEffect(() => {
+        async function preloadNextComic(id) {
+            let preloadNextComic = await getComic(id);
+            let { name } = preloadNextComic;
+            let srcSet = makeSrcSet(name);
+            new Image().setAttribute("srcset", srcSet);
+            visitedComics[id] = { ...preloadNextComic };
+            setVisitedComics(() => ({
+                ...visitedComics,
+            }));
+            setNextComic(() => ({ ...preloadNextComic }));
+        }
+        if (!visitedComics[comicID + 1] && count !== null && comicID !== count) {
+            preloadNextComic(comicID + 1);
+        }
+    }, [comicID, visitedComics, count]);
+
+    useEffect(() => {
+        async function preloadRandomComic(id) {
+            let preloadComic = await getComic(id);
+            let { name } = preloadComic;
+            let srcSet = makeSrcSet(name);
+            new Image().setAttribute("srcset", srcSet);
+            visitedComics[id] = { ...preloadComic };
+            setVisitedComics(() => ({
+                ...visitedComics,
+            }));
+            setUsedRandom(() => false);
+            setRandomComic(() => ({ ...preloadComic }));
+        }
+        let randomNumber;
+        if (count !== 0 && count !== null && count !== undefined && usedRandom === true) {
+            randomNumber = Math.floor(Math.random() * count);
+            if (randomNumber !== comicID) {
+                preloadRandomComic(randomNumber);
+            }
+        }
+    }, [count, usedRandom]);
 
     if (unavailable && !isLoading) {
         return (
@@ -195,44 +355,68 @@ const DisplayComic = () => {
     }
 
     return (
-        <div className={classes.comicWrapper}>
-            <IconButton onClick={() => handlePreviousComic(comicID - 1)} className={matches ? classes.hide : leftArrow}>
-                <ArrowBackIcon />
-            </IconButton>
-            {isLoading && !unavailable && (
-                <Comic
-                    src={src}
-                    // srcSet={srcSet}
-                    id={comicID}
-                    chipData={chipData}
-                    setChipData={setChipData}
-                    name={name}
-                    handleNextComic={handleNextComic}
-                    handlePreviousComic={handlePreviousComic}
-                    count={count}
-                    visible={false}
-                    isLoading={isLoading}
-                ></Comic>
-            )}
-            {!isLoading && !unavailable && (
-                <Comic
-                    src={src}
-                    srcSet={srcSet}
-                    id={comicID}
-                    chipData={chipData}
-                    setChipData={setChipData}
-                    name={name}
-                    handleNextComic={handleNextComic}
-                    handlePreviousComic={handlePreviousComic}
-                    count={count}
-                    visible={true}
-                ></Comic>
-            )}
-
-            <IconButton onClick={() => handleNextComic(comicID + 1)} className={matches ? classes.hide : rightArrow}>
-                <ArrowForwardIcon />
-            </IconButton>
-        </div>
+        <ThemeProvider theme={theme}>
+            <div className={classes.comicWrapper}>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <IconButton
+                        onClick={() => handlePreviousComic(comicID - 1)}
+                        className={matches ? classes.hide : leftArrow}
+                    >
+                        <ArrowBackIcon color="primary" />
+                    </IconButton>
+                    <IconButton onClick={handleFirstComic} className={matches ? classes.hide : leftArrow}>
+                        <SkipPreviousIcon color="primary" />
+                    </IconButton>
+                </div>
+                {isLoading && !unavailable && (
+                    <Comic
+                        src={src}
+                        // srcSet={srcSet}
+                        id={comicID}
+                        chipData={chipData}
+                        setChipData={setChipData}
+                        name={name}
+                        handleNextComic={handleNextComic}
+                        handlePreviousComic={handlePreviousComic}
+                        handleRandomComic={handleRandomComic}
+                        count={count}
+                        visible={false}
+                        isLoading={isLoading}
+                        reaction={reaction}
+                        setReaction={setReaction}
+                    ></Comic>
+                )}
+                {!isLoading && !unavailable && (
+                    <Comic
+                        src={src}
+                        srcSet={srcSet}
+                        id={comicID}
+                        chipData={chipData}
+                        setChipData={setChipData}
+                        name={name}
+                        handleNextComic={handleNextComic}
+                        handlePreviousComic={handlePreviousComic}
+                        handleRandomComic={handleRandomComic}
+                        count={count}
+                        visible={true}
+                        reaction={reaction}
+                        setReaction={setReaction}
+                        hideRandom={matches ? false : true}
+                    ></Comic>
+                )}
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <IconButton
+                        onClick={() => handleNextComic(comicID + 1)}
+                        className={matches ? classes.hide : rightArrow}
+                    >
+                        <ArrowForwardIcon color="primary" />
+                    </IconButton>
+                    <IconButton onClick={handleLastComic} className={matches ? classes.hide : rightArrow}>
+                        <SkipNextIcon color="primary" />
+                    </IconButton>
+                </div>
+            </div>
+        </ThemeProvider>
     );
 };
 

--- a/src/components/GlobalEmojiBar.js
+++ b/src/components/GlobalEmojiBar.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useState, useContext } from "react";
 import { UserContext } from "./UserContext";
-import { getUserEmoteData } from "../helpers/GrubbyAPI";
 
 import { makeStyles, createMuiTheme, ThemeProvider } from "@material-ui/core/styles";
 import Chip from "@material-ui/core/Chip";
@@ -14,6 +13,8 @@ import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { sendUserEmoteData, updateUserEmoteData, deleteReaction } from "../helpers/GrubbyAPI";
 
 import CustomSnackBar from "../components/CustomSnackBar";
+
+import MobileRandomComicButton from "../components/MobileRandomComicButton";
 
 const theme = createMuiTheme({
     palette: {
@@ -41,6 +42,7 @@ const useStyles = makeStyles((theme) => ({
     },
     chip: {
         margin: theme.spacing(0.5),
+        width: "60px",
     },
     leftArrow: {
         float: "left",
@@ -64,18 +66,33 @@ const useStyles = makeStyles((theme) => ({
         width: "100%",
         margin: "0.5vh 0",
         padding: theme.spacing(0.5),
+        display: "flex",
     },
     arrow: {
         fontSize: "2.5em",
     },
+    random: {
+        // flexGrow: 1,
+        margin: "auto",
+    },
 }));
 
-function GlobalEmojiBar({ id, chipData, setChipData, count, handleNextComic, handlePreviousComic, isLoading }) {
+function GlobalEmojiBar({
+    id,
+    chipData,
+    setChipData,
+    count,
+    handleNextComic,
+    handlePreviousComic,
+    handleRandomComic,
+    isLoading,
+    reaction,
+    setReaction,
+}) {
     const classes = useStyles();
     const matches = useMediaQuery("(max-width:900px)");
 
     const { user } = useContext(UserContext);
-    const [reaction, setReaction] = useState("");
     const [error, setError] = useState(false);
 
     const rightArrow = isLoading || id === count ? classes.invisibleRight : classes.rightArrow;
@@ -133,31 +150,14 @@ function GlobalEmojiBar({ id, chipData, setChipData, count, handleNextComic, han
         setError(false);
     };
 
-    useEffect(() => {
-        async function getEmoteData() {
-            try {
-                if (user) {
-                    if (id === null) {
-                        return;
-                    }
-                    let result = await getUserEmoteData(id, user);
-                    setReaction(() => result);
-                } else {
-                    // setReaction(() => "");
-                    return;
-                }
-            } catch (error) {
-                return;
-            }
-        }
-        getEmoteData();
-    }, [user, id]);
-
     return (
         <div>
             <div className={matches ? classes.arrowWrapper : classes.hide}>
                 <IconButton onClick={() => handlePreviousComic(id - 1)} className={matches ? leftArrow : classes.hide}>
                     <ArrowBackIcon className={classes.arrow} />
+                </IconButton>
+                <IconButton onClick={handleRandomComic} className={classes.random}>
+                    <MobileRandomComicButton visible={matches ? true : false} />
                 </IconButton>
                 <IconButton className={matches ? rightArrow : classes.hide} onClick={() => handleNextComic(id + 1)}>
                     <ArrowForwardIcon className={classes.arrow} />
@@ -174,10 +174,19 @@ function GlobalEmojiBar({ id, chipData, setChipData, count, handleNextComic, han
                                             avatar={
                                                 <span
                                                     role="img"
-                                                    style={{ fontSize: "1rem", backgroundColor: "transparent" }}
+                                                    style={{
+                                                        fontSize: "1rem",
+                                                        backgroundColor: "transparent",
+                                                        marginRight: "0 !important",
+                                                        marginBottom: "5px",
+                                                    }}
                                                     aria-labelledby={data.label}
                                                 >
-                                                    {data.icon}
+                                                    <img
+                                                        src={data.icon}
+                                                        style={{ width: "24px", height: "24px" }}
+                                                        alt={data.label}
+                                                    />
                                                 </span>
                                             }
                                             label={data.count}

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -216,7 +216,7 @@ const HomePage = () => {
                             <Typography variant="body1" component="div" className={classes.about} align="center">
                                 Hi it’s me, the author, Ian. <br /> Some context, Grubby the Grape lives with his
                                 roommate Dennis and his best friend Richard who doesn’t live with them but does sleep in
-                                the guest bedroom. Grubby’s wacky Richard’s street smart and Dennis has a child. I
+                                the guest bedroom. Grubby’s wacky, Richard’s street smart, and Dennis has a child. I
                                 update Grubby every Monday and Wednesday so stop on by and feel free to make an account
                                 where you can react using emojis or favorite comics to save em for later. BYE!
                             </Typography>

--- a/src/components/MobileRandomComicButton.js
+++ b/src/components/MobileRandomComicButton.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+    random: {
+        backgroundColor: "transparent",
+        display: "flex",
+        justifyContent: "center",
+        transform: "rotate(4deg)",
+        width: "60px",
+        height: "60px",
+        // flexGrow: 1,
+        maxWidth: "84px",
+    },
+    hidden: {
+        display: "none",
+    },
+}));
+
+const MobileRandomComicButton = ({ visible }) => {
+    const classes = useStyles();
+    return (
+        <img
+            src="https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/randomIcon.PNG"
+            alt="Random Comic"
+            className={visible ? classes.random : classes.hidden}
+        ></img>
+    );
+};
+
+export default MobileRandomComicButton;

--- a/src/components/RandomComicButton.js
+++ b/src/components/RandomComicButton.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Chip from "@material-ui/core/Chip";
+
+const useStyles = makeStyles((theme) => ({
+    random: {
+        margin: "8px",
+        backgroundColor: "#FFFFFF",
+        width: "58px",
+        [theme.breakpoints.up("sm")]: {
+            marginRight: 0,
+        },
+        [theme.breakpoints.up("md")]: {
+            marginRight: 0,
+        },
+        [theme.breakpoints.down("md")]: {
+            margin: "8px auto 10px auto",
+            maxWidth: "72px",
+        },
+
+        [theme.breakpoints.up("lg")]: {
+            marginRight: "auto",
+        },
+        "&:hover": {
+            background: "rgb(234, 234, 234)",
+        },
+    },
+    hidden: {
+        display: "none",
+    },
+    mobile: {
+        margin: "auto",
+        flexGrow: 1,
+        maxWidth: "58px",
+    },
+}));
+
+const RandomComicButton = ({ visible, mobile, handleRandomComic }) => {
+    const classes = useStyles();
+    let className;
+    if (visible === false) {
+        className = classes.hidden;
+    } else if (mobile) {
+        className = classes.mobile;
+    } else if (visible) {
+        className = classes.random;
+    } else {
+        className = classes.hidden;
+    }
+    return (
+        <Chip
+            avatar={
+                <span
+                    role="img"
+                    style={{
+                        fontSize: "1rem",
+                        backgroundColor: "transparent",
+                        display: "flex",
+                        justifyContent: "center",
+                        marginLeft: "20px",
+                        transform: "rotate(4deg)",
+                        marginBottom: "8px",
+                    }}
+                    aria-labelledby="Random Comic"
+                >
+                    <img
+                        style={{ width: "35px", height: "35px" }}
+                        src="https://grubbythegrape.sfo2.cdn.digitaloceanspaces.com/assets/assets/randomIcon.PNG"
+                        alt="Random Comic"
+                    ></img>
+                </span>
+            }
+            className={className}
+            color="primary"
+            clickable={true}
+            title="Random Comic"
+            onClick={handleRandomComic}
+        />
+    );
+};
+
+export default RandomComicButton;

--- a/src/helpers/GrubbyAPI.js
+++ b/src/helpers/GrubbyAPI.js
@@ -99,7 +99,7 @@ export async function getAllAdminComics() {
     }
 }
 
-export async function getPreviousComic(id) {
+export async function getComic(id) {
     try {
         let result = await axios.get(`${BASE_URL}/comic/${id}`);
         return result.data.comic;
@@ -270,6 +270,16 @@ export async function googleLogin(idToken) {
         console.error("API Error:", error.response);
         let message = error.response.data.message;
         throw Array.isArray(message) ? message : [message];
+    }
+}
+
+export async function getComicInfo(id) {
+    try {
+        let result = await axios.get(`${BASE_URL}/comic/${id}`);
+        return result.data.comic;
+    } catch (error) {
+        console.error("API Error:", error.response);
+        return;
     }
 }
 

--- a/src/routes/AuthRoute.js
+++ b/src/routes/AuthRoute.js
@@ -1,7 +1,11 @@
 import React from "react";
-import { Route } from "react-router-dom";
+import { Route, useHistory } from "react-router-dom";
 
 function AuthRoute({ exact, path, children }) {
+    const history = useHistory();
+    if (!localStorage.getItem("_token")) {
+        history.push("/");
+    }
     return (
         <Route exact={exact} path={path}>
             {children}


### PR DESCRIPTION
Major changes:

- ability to warp to the first comic
- ability to warp to the last comic
- ability to have a random comic selected for you
- implemented preloading technique for all of the above

So, when visiting the homepage, a total of 4 comics are loaded. The latest comic, the previous comic, the first comic, and a randomly chosen comic. I think this is a good tradeoff of performance with potential for the user to never request those comics (and thus waste data).